### PR TITLE
better handling of sql results being empty

### DIFF
--- a/src/MsSqlCdc/CdcDatabase.cs
+++ b/src/MsSqlCdc/CdcDatabase.cs
@@ -18,163 +18,90 @@ internal static class CdcDatabase
         return (bool?)(await command.ExecuteScalarAsync());
     }
 
-    public static async Task<bool> HasColumnChanged(
+    public static async Task<bool?> HasColumnChanged(
         SqlConnection connection,
         string captureInstance,
         string columnName,
         string updateMask)
     {
-        var sql = "sys.fn_cdc_has_column_changed(@capture_instance, @column_name, @update_mask) AS has_column_changed";
-
+        var sql = "sys.fn_cdc_has_column_changed(@capture_instance, @column_name, @update_mask)";
         using var command = new SqlCommand(sql, connection);
         command.Parameters.AddWithValue("@capture_instance", captureInstance);
         command.Parameters.AddWithValue("@column_name", columnName);
         command.Parameters.AddWithValue("@update_mask", updateMask);
 
-        using var reader = await command.ExecuteReaderAsync();
-
-        var hasColumnChanged = false;
-        while (await reader.ReadAsync())
-        {
-            hasColumnChanged = (bool)reader["has_column_changed"];
-        }
-
-        return hasColumnChanged;
+        return (bool?)(await command.ExecuteScalarAsync());
     }
 
-    public static async Task<int> GetColumnOrdinal(
+    public static async Task<int?> GetColumnOrdinal(
         SqlConnection connection,
         string captureInstance,
         string columnName)
     {
-        var sql = "SELECT sys.fn_cdc_get_column_ordinal(@capture_instance, @column_name) AS column_ordinal";
-
+        var sql = "SELECT sys.fn_cdc_get_column_ordinal(@capture_instance, @column_name)";
         using var command = new SqlCommand(sql, connection);
         command.Parameters.AddWithValue("@capture_instance", captureInstance);
         command.Parameters.AddWithValue("@column_name", columnName);
 
-        using var reader = await command.ExecuteReaderAsync();
-
-        var columnOrdinal = -1;
-        while (await reader.ReadAsync())
-        {
-            columnOrdinal = (int)reader["column_ordinal"];
-        }
-
-        return columnOrdinal;
+        return (int?)(await command.ExecuteScalarAsync());
     }
 
-    public static async Task<DateTime> MapLsnToTime(SqlConnection connection, long lsn)
+    public static async Task<DateTime?> MapLsnToTime(SqlConnection connection, long lsn)
     {
-        var sql = "SELECT sys.fn_cdc_map_lsn_to_time(@lsn) AS lsn_time";
+        var sql = "SELECT sys.fn_cdc_map_lsn_to_time(@lsn)";
 
         using var command = new SqlCommand(sql, connection);
         command.Parameters.AddWithValue("@lsn", lsn);
 
-        using var reader = await command.ExecuteReaderAsync();
-
-        var lsnTime = default(DateTime);
-        while (await reader.ReadAsync())
-        {
-            lsnTime = (DateTime)reader["lsn_time"];
-        }
-
-        if (lsnTime == default(DateTime))
-            throw new Exception($"Could not convert LSN to time with LSN being '{lsn}'");
-
-        return lsnTime;
+        return (DateTime?)(await command.ExecuteScalarAsync());
     }
 
-    public static async Task<byte[]> MapTimeToLsn(
+    public static async Task<byte[]?> MapTimeToLsn(
         SqlConnection connection,
         DateTime trackingTime,
         string relationOperator)
     {
-        var sql = "SELECT sys.fn_cdc_map_time_to_lsn(@relational_operator, @tracking_time) AS lsn";
-
+        var sql = "SELECT sys.fn_cdc_map_time_to_lsn(@relational_operator, @tracking_time)";
         using var command = new SqlCommand(sql, connection);
         command.Parameters.AddWithValue("@relational_operator", relationOperator);
         command.Parameters.AddWithValue("@tracking_time", trackingTime);
 
-        using var reader = await command.ExecuteReaderAsync();
-
-        var lsn = new byte[10];
-        while (await reader.ReadAsync())
-        {
-            lsn = (byte[])reader["lsn"];
-        }
-
-        return lsn;
+        return (byte[]?)(await command.ExecuteScalarAsync());
     }
 
-    public static async Task<byte[]> GetMinLsn(SqlConnection connection, string captureInstance)
+    public static async Task<byte[]?> GetMinLsn(SqlConnection connection, string captureInstance)
     {
-        var sql = "SELECT sys.fn_cdc_get_min_lsn(@capture_instance) AS min_lsn";
-
+        var sql = "SELECT sys.fn_cdc_get_min_lsn(@capture_instance)";
         using var command = new SqlCommand(sql, connection);
         command.Parameters.AddWithValue("@capture_instance", captureInstance);
 
-        using var reader = await command.ExecuteReaderAsync();
-
-        var minLsn = new byte[10];
-        while (await reader.ReadAsync())
-        {
-            minLsn = (byte[])reader["min_lsn"];
-        }
-
-        return minLsn;
+        return (byte[]?)(await command.ExecuteScalarAsync());
     }
 
-    public static async Task<byte[]> GetMaxLsn(SqlConnection connection)
+    public static async Task<byte[]?> GetMaxLsn(SqlConnection connection)
     {
         var sql = "SELECT sys.fn_cdc_get_max_lsn() AS max_lsn";
-
         using var command = new SqlCommand(sql, connection);
-        using SqlDataReader reader = await command.ExecuteReaderAsync();
 
-        var maxLsn = new byte[10];
-        while (await reader.ReadAsync())
-        {
-            maxLsn = (byte[])reader["max_lsn"];
-        }
-
-        return maxLsn;
+        return (byte[]?)(await command.ExecuteScalarAsync());
     }
 
-    public static async Task<byte[]> DecrementLsn(SqlConnection connection, long lsn)
+    public static async Task<byte[]?> DecrementLsn(SqlConnection connection, long lsn)
     {
         var sql = "SELECT sys.fn_cdc_decrement_lsn(@lsn) AS previous_lsn";
-
         using var command = new SqlCommand(sql, connection);
         command.Parameters.AddWithValue("@lsn", lsn);
 
-        using var reader = await command.ExecuteReaderAsync();
-
-        var nextLsn = new byte[10];
-        while (await reader.ReadAsync())
-        {
-            nextLsn = (byte[])reader["previous_lsn"];
-        }
-
-        return nextLsn;
+        return (byte[]?)(await command.ExecuteScalarAsync());
     }
 
-    public static async Task<byte[]> IncrementLsn(SqlConnection connection, long lsn)
+    public static async Task<byte[]?> IncrementLsn(SqlConnection connection, long lsn)
     {
         var sql = "SELECT sys.fn_cdc_increment_lsn(@lsn) AS next_lsn";
-
         using var command = new SqlCommand(sql, connection);
         command.Parameters.AddWithValue("@lsn", lsn);
 
-        using var reader = await command.ExecuteReaderAsync();
-
-        var nextLsn = new byte[10];
-        while (await reader.ReadAsync())
-        {
-            nextLsn = (byte[])reader["next_lsn"];
-        }
-
-        return nextLsn;
+        return (byte[]?)(await command.ExecuteScalarAsync());
     }
 
     public static async Task<List<List<(string fieldName, object fieldValue)>>> GetAllChanges(


### PR DESCRIPTION
Better handling of SQL results possibly being empty. In case they're now returned as NULL or empty values we throw an exception stating that the result did not match the requirements. This is done to avoid issues where the consumer of the library would retrieve `default(T)` values, which could possibly lead to hidden bugs.