### PR TITLE
updates Microsoft.Data.SqlClient dependency to version 5.2.1

### DIFF
--- a/src/MsSqlCdc/MsSqlCdc.csproj
+++ b/src/MsSqlCdc/MsSqlCdc.csproj
@@ -20,7 +20,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
The current Microsoft.Data.SqlClient has a security vulnability, updating to 5.2.1 resolves the issue.