### PR TITLE
Fix: Escaping CDC function names in SQL queries

### DIFF
--- a/src/MsSqlCdc/CdcDatabase.cs
+++ b/src/MsSqlCdc/CdcDatabase.cs
@@ -1,6 +1,7 @@
 using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace MsSqlCdc;
@@ -145,6 +146,14 @@ internal static class CdcDatabase
             endLsn,
             filterOption).ConfigureAwait(false);
     }
+    private const string SqlObjectNamePartSeparator = ".";
+    private static string EscapeSqlServerObjectName(string objectName)
+    {
+        return string
+        .Join(SqlObjectNamePartSeparator, objectName
+        .Split(SqlObjectNamePartSeparator)
+        .Select(namePart => $"[{namePart}]"));
+    }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage
     ("Security", "CA2100:Review SQL queries for security vulnerabilities",
@@ -157,7 +166,8 @@ internal static class CdcDatabase
         byte[] endLsn,
         string filterOption)
     {
-        var sql = $"SELECT * FROM {cdcFunction}_{captureInstance}(@begin_lsn, @end_lsn, @filter_option)";
+        var escapedCdcFunctionFullName = EscapeSqlServerObjectName($"{cdcFunction}_{captureInstance}");
+        var sql = $"SELECT * FROM {escapedCdcFunctionFullName} (@begin_lsn, @end_lsn, @filter_option)";
 
         using var command = new SqlCommand(sql, connection);
         _ = command.Parameters.AddWithValue("@begin_lsn", beginLsn);


### PR DESCRIPTION
Problem:
When using SQL Server Change Data Capture (CDC) functions in SQL queries, if capture instance names or other object identifiers contain special characters or reserved keywords, a SQL syntax error may occur when constructing dynamic SQL queries.

Solution:
1. Added EscapeSqlServerObjectName() function to properly escape SQL Server object identifiers
2. Function wraps each part of the object name (separated by dots) in square brackets []
3. Updated GetChangesAsync() method to use the escaped CDC function name in SQL queries
4. Added System.Linq dependency for LINQ method usage

Changed Files:
1. CdcDatabase.cs: addition of escaping function and its usage in SQL queries